### PR TITLE
Fix errors by wrong MultiRNNCell construction syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # SST-Tensorflow
 
+This is a modified version of [JaywongWang's implementation](https://github.com/JaywongWang/SST-Tensorflow). 
+
+Changes I've made:
+
+- The original repo has error in constructing MultiRNN cell, I've fixed it.
+- The pretrained model weights given by the original repo have conflicts with the code when loading, so I train the model again and offer my pretrained weights. And I also change the SaverDef version from V1 to V2, as suggested by TensorFlow. By the way, I set the model saving mechanism to only save the best results.
+- I add ploting val_loss, val_loss / reg_loss ratio in TensorBoard and create a folder named 'logs' to hold all these tfevents files.
+- Learing rate reduce schedule and other minor improvements.
+
+Following is from the readme file in JaywongWang's original repo. Sentences marked with **NOTE** are introduced by me and you should read them carefully.
+
+------------
+
 Tensorflow Implementation of the Paper [SST: Single-Stream Temporal Action Proposals](http://vision.stanford.edu/pdf/buch2017cvpr.pdf) by Shyamal Buch *et al.* in *CVPR* 2017.
 
 
 ### Data Preparation
 
-Please download video data and annotation data from the website [THUMOS14](http://crcv.ucf.edu/THUMOS14/download.html). Extract C3D features for non-overlap 16-frame snippets from the 412 videos (200 val videos + 212 test videos, I found one test video missing) for the task of temporal action proposals. Alternatively, you may download my provided [C3D features](https://pan.baidu.com/s/1ggMHZ71), and put them in dataset/thumos14/features/. If you are interested in the feature extraction, I refer you to this [code](https://github.com/yyuanad/Pytorch_C3D_Feature_Extractor).
+Please download video data and annotation data from the website [THUMOS14](http://crcv.ucf.edu/THUMOS14/download.html). Extract C3D features for non-overlap 16-frame snippets from the 412 videos (200 val videos + 212 test videos, I found one test video missing) for the task of temporal action proposals. Alternatively, if you don't want to download the dataset and perform the c3d  preprocessing,  you may download my provided [C3D features](https://pan.baidu.com/s/1ggMHZ71), and put them in dataset/thumos14/features/. If you are interested in the feature extraction, I refer you to this [code](https://github.com/yyuanad/Pytorch_C3D_Feature_Extractor).
 
 *fc6* features are used in my experiment.
 
@@ -17,6 +30,8 @@ After that, please generate anchor weights (for handling imbalance class problem
 ### Hyper Parameters
 
 The best configuration (from my experiments) is given in opt.py, including model setup, training options, and testing options.
+
+**Note**: My config is slightly different from Jay's repo.
 
 ### Training
 
@@ -34,6 +49,8 @@ Follow the script eval.py to evaluate your proposal predictions.
 
 You may download my trained model [here](https://pan.baidu.com/s/1mjBI2Nm). Please put them in checkpoints/. Change the file init_from in opt.py and run test.py !
 
+**Note**: Jay's pretrained model fails to load in my experiment. You can use my pretrained model here: [Google Drive link](https://drive.google.com/drive/folders/1dzjeC-B1rDV-gpvBvQRqYN6fwL3sEEIj?usp=sharing). Usage: `python test.py --init_from=checkpoints/1/epoch18_34.54_lr0.001000.ckpt`
+
 **Update:** The predicted action proposals for the test set can be found [here](https://pan.baidu.com/s/1nwa2VLv). The result figures are put in results/1. They are slightly better than the reported ones.
 
 <table>
@@ -46,9 +63,15 @@ You may download my trained model [here](https://pan.baidu.com/s/1mjBI2Nm). Plea
     <th>0.672</th>
   </tr>
   <tr>
-    <th>SST (my impl)</th>
+    <th>SST (Jay's impl)</th>
     <th>0.696</th>
   </tr>
+
+ <tr>
+    <th>SST (My impl)</th>
+    <th>0.697</th>
+  </tr>
+
 </table>
 
 ![alt text](results/1/sst_recall_vs_proposal.png "Average Recall vs Average Proposal Number")
@@ -57,12 +80,12 @@ You may download my trained model [here](https://pan.baidu.com/s/1mjBI2Nm). Plea
 
 ### Dependencies
 
-tensorflow==1.0.1
+tensorflow-gpu(I have tested on tf1.4 and 1.6)
 
-python==2.7.5
+python2
 
 Other versions may also work.
 
 ### Acknowledgements
 
-Great thanks to Shyamal Buch for really helpful discussion.
+Great thanks to JaywongWang's tensorflow reimplementation.

--- a/dataset/thumos14/prepare_gt_proposal_data.py
+++ b/dataset/thumos14/prepare_gt_proposal_data.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 '''
 data format: vid1: [{'timestamp': [t0, t1]}, {'timestamp': [t2, t3]}], vid2: [], ...
 
@@ -19,6 +20,7 @@ test_anno_folder = 'th14_temporal_annotations_test/annotation'
 
 
 video_info_file = 'thumos_video_info.json' # THUMOS14 website provided meta data, I already convert original .mat data to .json data
+# type: dict
 video_info = json.load(open(video_info_file, 'r'))
 
 sources = {'val': val_anno_folder, 'test': test_anno_folder}
@@ -26,10 +28,14 @@ sources = {'val': val_anno_folder, 'test': test_anno_folder}
 
 val_split = {'train': 0.8, 'val': 0.2}  # further split validation set into train set and validation set
 
-# feature file
+# feature file: len(feat_data.keys())=412, 412 videos
+# feat_data has 412 groups, each group has 3 members: [u'c3d_features', u'total_frames', u'valid_frames'] (each is a dataset)
+# for example:
+# input: feat_data['video_validation_0000987']['c3d_features']
+# output: <HDF5 dataset "c3d_features": shape (192, 4096), type "<f4">     (192 = valid_frames / 16)
+# you can use feat_data['video_validation_0000987']['c3d_features'].value to access the feat data
 feat_path = 'features/thumos14_c3d_fc6.hdf5'
 feat_data = h5py.File(feat_path, 'r')
-
 
 feat_resolution = 16
 
@@ -47,7 +53,7 @@ for split in sources.keys():
 		for line in annos:
 			items = line.strip().split()
 			assert len(items) == 3
-			vid = items[0]
+			vid = items[0]  # video name
 
 			extracted_frame_num = int(feat_data[vid]['total_frames'].value)
 			valid_frame_num = int(feat_data[vid]['valid_frames'].value)

--- a/log/readme.txt
+++ b/log/readme.txt
@@ -1,0 +1,1 @@
+tensorboard files will be here.

--- a/opt.py
+++ b/opt.py
@@ -40,7 +40,7 @@ def default_options():
     options['batch_size'] = 160      # training batch size
     options['eval_batch_size'] = 40  # evaluation (loss) batch size
     options['learning_rate'] = 1e-3  # initial learning rate (I fix learning rate to 1e-3 during training phase)
-    options['reg'] = 1e-5            # regularization strength (control L2 regularization ratio)
+    options['reg'] = 1e-2            # regularization strength (control L2 regularization ratio)
     options['init_scale'] = 0.08     # the init scale for uniform distribution
     options['max_epochs'] = 100    # maximum training epochs to run
     options['init_epoch'] = 0        # initial epoch (useful when you needs to continue from some checkpoints)
@@ -49,7 +49,7 @@ def default_options():
     options['shuffle'] = True        # whether do data shuffling for training set
     options['clip_gradient_norm'] = 100.0      # threshold to clip gradients: avoid gradient exploding problem; set to -1 to remove gradient clipping
     options['log_input_min']  = 1e-20          # minimum input to the log() function
-    options['sample_len'] = 2048/16 + 1        # the length ratio of the sampled stream compared to the video 
+    options['sample_len'] = 2048/16        # the length ratio of the sampled stream compared to the video 
     options['proposal_tiou_threshold'] = 0.5   # tiou threshold to generate positive samples, when changed, re-calculate class weights for positive/negative class
     options['n_iters_display'] = 1             # display frequency
     options['ckpt_prefix'] = 'checkpoints/' + str(options['train_id']) + '/' # folder path to save checkpionts during training 


### PR DESCRIPTION
Correct the mistakes caused by `[lstm]*2` style-like MultiRNNCell construction syntax. The corresponding error is "ValueError: Dimensions must be equal...". Low TensorFlow version (like 1.0) might ignore this and run without errors. But with higher version, this syntax fails. `[lstm]*2` syntax just creates two exactly same lstm instances which is actually wrong. 
More detail can be found in the discussion here: https://github.com/tensorflow/tensorflow/issues/14897